### PR TITLE
Support monoio 0.0.9, fix lifetime issues and bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,17 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,26 +112,24 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -153,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -210,15 +197,36 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -315,25 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +346,9 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -419,6 +408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +425,18 @@ checksum = "f307526c6df4dfab4067c60bc7160324d2ef41eb0dc5a64fd25d96be17ea032c"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -451,9 +462,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -494,14 +511,12 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "monoio"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99942998d5959cbfc79c9a847fd6d6270f16b02d99b2f79e05a8d7801b264b3"
+version = "0.0.9"
 dependencies = [
  "bytes",
  "fxhash",
@@ -511,16 +526,13 @@ dependencies = [
  "monoio-macros",
  "nix",
  "pin-project-lite",
- "scoped-tls",
  "socket2",
  "windows",
 ]
 
 [[package]]
 name = "monoio-codec"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62682b001fa18b2eda4ee6b2f7e524b7c25544c951871e7f64efee7040109e06"
+version = "0.0.4"
 dependencies = [
  "bytes",
  "monoio",
@@ -529,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "monoio-gateway"
-version = "0.0.1"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -551,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "monoio-gateway-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "acme-lib",
  "anyhow",
@@ -574,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "monoio-gateway-examples"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "monoio",
@@ -586,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "monoio-gateway-services"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "acme-lib",
  "anyhow",
@@ -605,24 +617,19 @@ dependencies = [
 
 [[package]]
 name = "monoio-http"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bytes",
- "h2",
  "http",
  "httparse",
  "monoio",
  "monoio-codec",
- "monoio-rustls",
- "rustls 0.20.6",
  "thiserror",
 ]
 
 [[package]]
 name = "monoio-macros"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85c9d2114c190b1ec18da29bfbe399a95d81657633b0d2333d4084515aa9f95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -631,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "monoio-rustls"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bytes",
  "monoio",
@@ -902,6 +909,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,12 +961,6 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "sct"
@@ -1138,12 +1153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "thiserror"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,8 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
- "bytes",
- "memchr",
  "once_cell",
  "pin-project-lite",
  "socket2",
@@ -1526,17 +1533,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.40.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30acc718a52fb130fec72b1cb5f55ffeeec9253e1b785e94db222178a6acaa1"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.40.0",
- "windows_i686_gnu 0.40.0",
- "windows_i686_msvc 0.40.0",
- "windows_x86_64_gnu 0.40.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.40.0",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]
@@ -1553,10 +1560,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.40.0"
+name = "windows-sys"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3caa4a1a16561b714323ca6b0817403738583033a6a92e04c5d10d4ba37ca10"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1566,9 +1588,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328973c62dfcc50fb1aaa8e7100676e0b642fe56bac6bafff3327902db843ab4"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1578,9 +1600,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5b09fad70f0df85dea2ac2a525537e415e2bf63ee31cf9b8e263645ee9f3c1"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1590,9 +1612,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ad4031c1a98491fa195d8d43d7489cb749f135f2e5c4eed58da094bd0d876"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1602,15 +1624,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520ff37edd72da8064b49d2281182898e17f0688ae9f4070bca27e4b5c162ac7"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e5b82215102c44fd75f488f1b9158973d02aa34d06ed85c23d6f5520a2853"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1620,6 +1642,6 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0c9c6df55dd1bfa76e131cef44bdd8ec9c819ef3611f04dfe453fd5bfeda28"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoio-gateway-examples"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,8 +9,8 @@ edition = "2021"
 monoio-gateway = {path = '../monoio-gateway'}
 monoio-gateway-core = {path = '../monoio-gateway-core', features = ['full']}
 monoio-gateway-services = {path = '../monoio-gateway-services'}
-monoio = {version = "0.0.8", features = ['splice']}
-monoio-http = {path = '../../monoio-http/monoio-http'}
+monoio = {version = "0.0.9", features = ['splice'], path = "../../monoio/monoio"}
+monoio-http = {version = "0.0.2", path = '../../monoio-http/monoio-http'}
 anyhow = "1"
 
 

--- a/monoio-gateway-core/Cargo.toml
+++ b/monoio-gateway-core/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "monoio-gateway-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-monoio = {version = "0.0.8", features = ['splice']}
-monoio-http = {path = "../../monoio-http/monoio-http"}
-monoio-rustls = {path = "../../monoio-tls/monoio-rustls", features = ["tls12"], default-features=false}
+monoio = {version = "0.0.9", features = ['splice'], path = "../../monoio/monoio"}
+monoio-http = {version = "0.0.2", path = "../../monoio-http/monoio-http"}
+monoio-rustls = {version = "0.0.7", path = "../../monoio-tls/monoio-rustls", features = ["tls12"], default-features=false}
 
 thiserror = "1"
 anyhow = "1"

--- a/monoio-gateway-core/src/acme/acme.rs
+++ b/monoio-gateway-core/src/acme/acme.rs
@@ -77,7 +77,7 @@ impl Acme for GenericAcme {
 
     type Error = GError;
 
-    type Future<'cx> = impl Future<Output = Result<Option<Self::Response>, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Option<Self::Response>, Self::Error>> + 'cx
         where Self: 'cx;
 
     fn acme(&self, _: ()) -> Self::Future<'_> {

--- a/monoio-gateway-core/src/discover/discover.rs
+++ b/monoio-gateway-core/src/discover/discover.rs
@@ -19,8 +19,8 @@ where
     type Error = GError;
 
     type DiscoverFuture<'a> = impl Future<
-    Output = Result<Option<DiscoverChange<Self::Key, Self::Service>>, Self::Error>,
->
+        Output = Result<Option<DiscoverChange<Self::Key, Self::Service>>, Self::Error>,
+    > + 'a
     where
         Self: 'a;
 

--- a/monoio-gateway-core/src/dns/http.rs
+++ b/monoio-gateway-core/src/dns/http.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::{Display, Write},
+    fmt::Display,
     future::Future,
 };
 
@@ -69,7 +69,7 @@ impl Resolvable for Domain {
 
     type Address = String;
 
-    type ResolveFuture<'a> = impl Future<Output = Result<Option<Self::Address>, Self::Error>>
+    type ResolveFuture<'a> = impl Future<Output = Result<Option<Self::Address>, Self::Error>> + 'a
     where
         Self: 'a;
 

--- a/monoio-gateway-core/src/dns/tcp.rs
+++ b/monoio-gateway-core/src/dns/tcp.rs
@@ -23,7 +23,7 @@ impl TcpAddress {
 impl Resolvable for TcpAddress {
     type Error = anyhow::Error;
 
-    type ResolveFuture<'a> = impl Future<Output = Result<Option<SocketAddr>, Self::Error>>;
+    type ResolveFuture<'a> = impl Future<Output = Result<Option<SocketAddr>, Self::Error>> + 'a;
 
     type Address = SocketAddr;
 

--- a/monoio-gateway-core/src/http/ssl.rs
+++ b/monoio-gateway-core/src/http/ssl.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, fs::File, io::BufReader, path::Path};
 
 use anyhow::bail;
 use monoio_rustls::TlsConnector;
-use rustls::{internal::msgs::codec::Codec, server::ResolvesServerCert};
+use rustls::server::ResolvesServerCert;
 
 use crate::{error::GError, CERTIFICATE_MAP, DEFAULT_SSL_CLIENT_CONFIG};
 

--- a/monoio-gateway-core/src/lib.rs
+++ b/monoio-gateway-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 #[cfg(feature = "acme")]

--- a/monoio-gateway-core/src/service.rs
+++ b/monoio-gateway-core/src/service.rs
@@ -23,6 +23,7 @@ pub trait Layer<S> {
     fn layer(&self, service: S) -> Self::Service;
 }
 
+#[allow(dead_code)]
 pub struct SvcList<S>
 where
     S: IntoIterator,
@@ -30,6 +31,7 @@ where
     inner: Enumerate<S::IntoIter>,
 }
 
+#[allow(dead_code)]
 type ListSvcList<S> = SvcList<Vec<S>>;
 
 pub struct ServiceBuilder<L> {

--- a/monoio-gateway-core/src/transfer/mod.rs
+++ b/monoio-gateway-core/src/transfer/mod.rs
@@ -49,7 +49,7 @@ pub async fn copy_stream_sink<I, Read, Write>(
 where
     Read: Stream<Item = Result<I, DecodeError>> + FillPayload,
     Write: Sink<I>,
-    I: IntoParts,
+    I: IntoParts + 'static,
 {
     loop {
         match local.next().await {

--- a/monoio-gateway-services/Cargo.toml
+++ b/monoio-gateway-services/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "monoio-gateway-services"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-monoio = {version = "0.0.8", features = ['splice']}
+monoio = {version = "0.0.9", features = ['splice'], path = "../../monoio/monoio"}
 monoio-gateway-core = {path = "../monoio-gateway-core"}
-monoio-http = {path = "../../monoio-http/monoio-http"}
-monoio-rustls = {path = "../../monoio-tls/monoio-rustls", features = ["tls12"], default-features=false}
+monoio-http = {version = "0.0.2", path = "../../monoio-http/monoio-http"}
+monoio-rustls = {version = "0.0.7", path = "../../monoio-tls/monoio-rustls", features = ["tls12"], default-features=false}
 # tls
 rustls = {version = "0.20", features = ["tls12"]}
 rustls-pemfile = "1"

--- a/monoio-gateway-services/src/layer/auth.rs
+++ b/monoio-gateway-services/src/layer/auth.rs
@@ -14,7 +14,7 @@ impl Service<Request> for BearerAuthService {
 
     type Error = GError;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/layer/delay.rs
+++ b/monoio-gateway-services/src/layer/delay.rs
@@ -12,12 +12,13 @@ pub struct DelayService<T> {
 impl<R, T> Service<R> for DelayService<T>
 where
     T: Service<R>,
+    R: 'static,
 {
     type Response = T::Response;
 
     type Error = T::Error;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/layer/discover.rs
+++ b/monoio-gateway-services/src/layer/discover.rs
@@ -19,7 +19,7 @@ where
 
     type Error = D::Error;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/layer/listen.rs
+++ b/monoio-gateway-services/src/layer/listen.rs
@@ -23,7 +23,7 @@ where
 
     type Error = GError;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/layer/router.rs
+++ b/monoio-gateway-services/src/layer/router.rs
@@ -72,7 +72,7 @@ where
 
     type Error = GError;
 
-    type Future<'a> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'a> = impl Future<Output = Result<Self::Response, Self::Error>> + 'a
     where
         Self: 'a;
 
@@ -178,7 +178,7 @@ where
 
     type Error = GError;
 
-    type Future<'a> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'a> = impl Future<Output = Result<Self::Response, Self::Error>> + 'a
     where
         Self: 'a;
 

--- a/monoio-gateway-services/src/layer/timeout.rs
+++ b/monoio-gateway-services/src/layer/timeout.rs
@@ -14,12 +14,13 @@ impl<R, T> Service<R> for TimeoutService<T>
 where
     T: Service<R>,
     T::Error: Display,
+    R: 'static,
 {
     type Response = Option<T::Response>;
 
     type Error = GError;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/layer/tls.rs
+++ b/monoio-gateway-services/src/layer/tls.rs
@@ -37,13 +37,13 @@ pub trait Tls {
 impl<T, S> Service<Accept<S>> for TlsService<T>
 where
     T: Service<TlsAccept<S>>,
-    S: Split + AsyncReadRent + AsyncWriteRent,
+    S: Split + AsyncReadRent + AsyncWriteRent + 'static,
 {
     type Response = T::Response;
 
     type Error = GError;
 
-    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>>
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
     where
         Self: 'cx;
 

--- a/monoio-gateway-services/src/lib.rs
+++ b/monoio-gateway-services/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 pub mod layer;

--- a/monoio-gateway/Cargo.toml
+++ b/monoio-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoio-gateway"
-version = "0.0.1"
+version = "0.1.1"
 edition = "2021"
 keywords = ["monoio", "http", "async"]
 description = "The gateway plugin for monoio"
@@ -8,11 +8,11 @@ description = "The gateway plugin for monoio"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-monoio-gateway-core = {path = "../monoio-gateway-core", features = ['full']}
-monoio-gateway-services = {path = "../monoio-gateway-services"}
+monoio-gateway-core = { path = "../monoio-gateway-core", features = ['full'] }
+monoio-gateway-services = { path = "../monoio-gateway-services" }
 
-monoio = {version = "0.0.8"}
-monoio-http = {path = "../../monoio-http/monoio-http"}
+monoio = { version = "0.0.9", path = "../../monoio/monoio" }
+monoio-http = { version = "0.0.2", path = "../../monoio-http/monoio-http" }
 
 bytes = "1"
 http = "0.2"
@@ -20,11 +20,11 @@ httparse = "1"
 thiserror = "1"
 anyhow = "1"
 # logger
-env_logger = "0.9"
+env_logger = "0.10"
 log = "0.4"
-clap = {version = "3", features = ['derive']}
+clap = { version = "4", features = ['derive'] }
 
-tower = {version = "0.4", features = ["full"]}
+tower = { version = "0.4", features = ["full"] }
 
 serde = "1"
 serde_json = "1"

--- a/monoio-gateway/src/gateway.rs
+++ b/monoio-gateway/src/gateway.rs
@@ -30,7 +30,7 @@ pub struct Gateway<Addr> {
 }
 
 impl Gatewayable<TcpAddress> for Gateway<TcpAddress> {
-    type GatewayFuture<'cx> = impl Future<Output = Result<(), GError>> where Self: 'cx;
+    type GatewayFuture<'cx> = impl Future<Output = Result<(), GError>> + 'cx where Self: 'cx;
 
     fn new(config: Vec<RouterConfig<TcpAddress>>) -> Self {
         Self { config }
@@ -60,7 +60,7 @@ impl Gatewayable<TcpAddress> for Gateway<TcpAddress> {
 }
 
 impl Gatewayable<Domain> for Gateway<Domain> {
-    type GatewayFuture<'cx> = impl Future<Output = Result<(), GError>> where Self: 'cx;
+    type GatewayFuture<'cx> = impl Future<Output = Result<(), GError>> + 'cx where Self: 'cx;
 
     fn new(config: Vec<RouterConfig<Domain>>) -> Self {
         Self { config }
@@ -109,7 +109,7 @@ where
     A: Resolvable + Send + 'static,
     Gateway<A>: Gatewayable<A>,
 {
-    type Future<'a> = impl Future<Output = Result<(), GError>>
+    type Future<'a> = impl Future<Output = Result<(), GError>> + 'a
      where Self: 'a;
 
     fn serve(&self) -> Self::Future<'_> {

--- a/monoio-gateway/src/lib.rs
+++ b/monoio-gateway/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 pub mod gateway;

--- a/monoio-gateway/src/main.rs
+++ b/monoio-gateway/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 use std::thread;

--- a/monoio-gateway/src/proxy/h1.rs
+++ b/monoio-gateway/src/proxy/h1.rs
@@ -33,7 +33,7 @@ pub struct HttpProxy {
 
 impl Proxy for HttpProxy {
     type Error = GError;
-    type OutputFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type OutputFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
     fn io_loop(&self) -> Self::OutputFuture<'_> {
         async {

--- a/monoio-gateway/src/proxy/tcp.rs
+++ b/monoio-gateway/src/proxy/tcp.rs
@@ -19,7 +19,7 @@ pub struct TcpProxy {
 
 impl Proxy for TcpProxy {
     type Error = anyhow::Error;
-    type OutputFuture<'a> = impl Future<Output = Result<(), Self::Error>> where Self: 'a;
+    type OutputFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
 
     fn io_loop(&self) -> Self::OutputFuture<'_> {
         async {


### PR DESCRIPTION
Support monoio 0.0.9, fix lifetime issues and bump version to 0.1.1

```
Finished dev [unoptimized + debuginfo] target(s) in 0.11s
```

```
 Finished test [unoptimized + debuginfo] target(s) in 7.13s
     Running unittests src/lib.rs (target/debug/deps/monoio_gateway-ecc20ddb7e7ae0cb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/monoio_gateway-fa35ac7961e67c79)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/monoio_gateway_core-87d7860c1f32cab8)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/monoio_gateway_services-bf0b5c75c4d5bc42)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests monoio-gateway

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests monoio-gateway-core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests monoio-gateway-services

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```